### PR TITLE
Possible new Option?

### DIFF
--- a/jquery.meanmenu.js
+++ b/jquery.meanmenu.js
@@ -107,6 +107,7 @@
             function meanOriginal() {
             	jQuery('.mean-bar,.mean-push').replaceWith('');
             	jQuery('body').removeClass("mean-container");
+				jQuery(meanMenu).children().addClass(meanRemoveClass);
             	jQuery(meanMenu).show();
             }
             


### PR DESCRIPTION
I found that classes were still being carried into the new menu and existing CSS made it difficult to customize unless I could remove it.

The new option "meanRemoveClass" allows you to define a class in the normal menu markup that can be removed from the mean menu in case it is needed for conflicts with existing css.

Hope that helps! Might be a better way to do it?
