### PR TITLE
box-sizing content-box

### DIFF
--- a/meanmenu.css
+++ b/meanmenu.css
@@ -24,6 +24,11 @@ padding: 4px 0;
 min-height: 42px;
 z-index: 999999;
 }
+.mean-container .mean-bar * {
+-webkit-box-sizing: content-box;
+-moz-box-sizing: content-box;
+box-sizing: content-box;
+}
 .mean-container a.meanmenu-reveal {
 width: 22px;
 height: 22px;


### PR DESCRIPTION
When working with frameworks using `box-sizing: border-box` for the page layout, meanMenu does not work out-of-the-box. All elements within .mean-bar rely on `box-sizing: content-box`. I don't know if you think this should be included in your css or not, it's just a little suggestion.
