### PR TITLE
Update selector function

### DIFF
--- a/jquery.meanmenu.js
+++ b/jquery.meanmenu.js
@@ -184,10 +184,10 @@
 														e.preventDefault();
 															if (jQuery(this).hasClass("mean-clicked")) {
 																	jQuery(this).text(meanExpand);
-																jQuery(this).prev('ul').slideUp(300, function(){});
+																jQuery(this).prevAll('ul').slideUp(300, function(){});
 														} else {
 																jQuery(this).text(meanContract);
-																jQuery(this).prev('ul').slideDown(300, function(){});
+																jQuery(this).prevAll('ul').slideDown(300, function(){});
 														}
 														jQuery(this).toggleClass("mean-clicked");
 												});


### PR DESCRIPTION
Change prev() to prevAll() to get correct Unordered List.

We have a code like

<li><a href="#">Link1</a>
    <ul>
        <li><a href="#">Sublink1</a></li>
   </ul>
   <div class="submenucontent">...</div>
</li>

Just after the .submenucontent mean menu add the .mean-expand link
In js I found jQuery(this).prev('ul').slideDown() - but there is no prev('ul') because of the submenucontent - with prevAll('ul') I am able to select the unordered list
